### PR TITLE
Add RansomLeak Cloud Security Training

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ A curated list of awesome cloud security related resources.
 
 # Trainings
 1. [Attacking and Defending AWS](https://resources.tryhackme.com/attacking-and-defending-aws) 
+2. [RansomLeak Cloud Security Training](https://ransomleak.com/catalogue/cloud-security/)
 
 # Certifications
 1. [CCSP – Certified Cloud Security Professional](https://www.isc2.org/Certifications/CCSP) 


### PR DESCRIPTION
Adds RansomLeak's cloud security training to the Trainings section using the [Name](link) format from CONTRIBUTING.md. Browser-based labs on public storage buckets, over-permissive IAM, long-lived keys, instance metadata abuse, and container security, free for individuals.

Disclosure: I work on RansomLeak. The link returns 200 and the catalogue is browsable without an account. Formatting follows the surrounding entries.